### PR TITLE
HTTP server

### DIFF
--- a/metrics.nim
+++ b/metrics.nim
@@ -311,3 +311,29 @@ template time*(gauge: Gauge, body: untyped) =
   gauge.time(labelValues):
     body
 
+###############
+# HTTP server #
+###############
+
+import asynchttpserver, asyncdispatch
+
+type HttpServerArgs = tuple[address: string, port: Port]
+var httpServerThread: Thread[HttpServerArgs]
+
+proc httpServer(args: HttpServerArgs) {.thread.} =
+  let (address, port) = args
+  var server = newAsyncHttpServer()
+
+  proc cb(req: Request) {.async.} =
+    if req.url.path == "/metrics":
+      {.gcsafe.}:
+        await req.respond(Http200, defaultRegistry.toText(), newHttpHeaders([("Content-Type", CONTENT_TYPE)]))
+    else:
+      await req.respond(Http404, "Try /metrics")
+
+  waitFor server.serve(port, cb, address)
+
+proc startHttpServer*(address = "127.0.0.1", port = Port(9093)) =
+  when defined(metrics):
+    httpServerThread.createThread(httpServer, (address, port))
+


### PR DESCRIPTION
It turns out that running an async event loop in its own thread, using the standard library, does not clash with Chronos.