### PR TITLE
alternative API

### DIFF
--- a/benchmarks/bench_collectors.nim
+++ b/benchmarks/bench_collectors.nim
@@ -4,19 +4,23 @@ import
 proc main(nb_samples: Natural) =
   warmup()
 
-  bench("create a counter and increment it 3 times with different values", 0):
+  var res: float64
+
+  bench("create a counter and increment it 3 times with different values", res):
     declareCounter counter1, "help"
     counter1.inc()
     counter1.inc(2)
     counter1.inc(2.1)
+    res = counter1.value
     counter1.unregister()
 
   let labelValues = @["a", "b"]
-  bench("create a counter with 2 labels and increment it 3 times with different values", 0):
+  bench("create a counter with 2 labels and increment it 3 times with different values", res):
     declareCounter counter2, "help", @["foo", "bar"]
     counter2.inc(labelValues = labelValues)
     counter2.inc(2, labelValues)
     counter2.inc(2.1, labelValues)
+    res = counter2.value(labelValues)
     counter2.unregister()
 
 when isMainModule:

--- a/metrics.nim
+++ b/metrics.nim
@@ -225,15 +225,16 @@ template declarePublicCounter*(identifier: untyped,
 #- alternative API (without support for custom help strings, labels or custom registries)
 #- different collector types with the same names are allowed
 #- don't mark this proc as {.inline.} because it's incompatible with {.global.}: https://github.com/status-im/nim-metrics/pull/5#discussion_r304687474
-proc counter*(name: static string): Counter | type IgnoredCollector =
-  when defined(metrics):
+when defined(metrics):
+  proc counter*(name: static string): Counter =
     # This {.global.} var assignment is lifted from the procedure and placed in a
     # special module init section that's guaranteed to run only once per program.
     # Calls to this proc will just return the globally initialised variable.
     var res {.global.} = newCounter(name, "")
     return res
-  else:
-    return IgnoredCollector
+else:
+  template counter*(name: static string): untyped =
+    IgnoredCollector
 
 proc incCounter(counter: Counter, amount: int64|float64 = 1, labelValues: Labels = @[]) =
   when defined(metrics):
@@ -318,12 +319,13 @@ template declareGauge*(identifier: untyped,
     type identifier = IgnoredCollector
 
 # alternative API
-proc gauge*(name: static string): Gauge | type IgnoredCollector =
-  when defined(metrics):
+when defined(metrics):
+  proc gauge*(name: static string): Gauge =
     var res {.global.} = newGauge(name, "") # lifted line
     return res
-  else:
-    return IgnoredCollector
+else:
+  template gauge*(name: static string): untyped =
+    IgnoredCollector
 
 template declarePublicGauge*(identifier: untyped,
                             help: static string,

--- a/metrics.nimble
+++ b/metrics.nimble
@@ -30,6 +30,8 @@ task test, "Main tests":
   # build it with metrics disabled, first
   buildBinary "main_tests", "tests/", "-f"
   test "main_tests"
+  buildBinary "bench_collectors", "benchmarks/", "-f"
+  buildBinary "bench_collectors", "benchmarks/", "-f -d:metrics"
 
 task test_chronicles, "Chronicles tests":
   buildBinary "chronicles_tests", "tests/", "-f"

--- a/tests/chronicles_tests.nim
+++ b/tests/chronicles_tests.nim
@@ -11,16 +11,16 @@ import chronicles, tables, unittest,
 suite "logging":
   test "info":
     var registry = newRegistry()
-    declareCounter counter, "help", registry = registry
-    counter.inc()
-    info "counter", counter
-    declareCounter lcounter, "l help", @["foo", "bar"], registry
+    declareCounter myCounter, "help", registry = registry
+    myCounter.inc()
+    info "myCounter", myCounter
+    declareCounter lCounter, "l help", @["foo", "bar"], registry
     let labelValues = @["a", "x \"y\" \n\\z"]
-    lcounter.inc(4.5, labelValues = labelValues)
-    info "lcounter", lcounter
-    declareGauge gauge, "help", registry = registry
-    gauge.set(9.5)
-    info "gauge", gauge
+    lCounter.inc(4.5, labelValues = labelValues)
+    info "lCounter", lCounter
+    declareGauge myGauge, "help", registry = registry
+    myGauge.set(9.5)
+    info "myGauge", myGauge
     when defined(metrics):
       for collector, metricsTable in registry.collect():
         for labels, metrics in metricsTable:

--- a/tests/main_tests.nim
+++ b/tests/main_tests.nim
@@ -37,19 +37,13 @@ suite "counter":
     expect ValueError:
       myCounter.inc(-1)
 
-    # alternative API
-    counter("myCounter", registry = registry).inc()
-    check(counter("myCounter", registry = registry).value == 9.5)
-    check(myCounter.value == 9.5)
-    counter("myNewCounter", registry = registry).inc()
-    check(counter("myNewCounter", registry = registry).value == 1)
-    # default registry
-    counter("foo_bar").inc()
-    check(counter("foo_bar").value == 1)
-    counter("foo_bar").inc(0.5)
-    check(counter("foo_bar").value == 1.5)
-    expect ObjectConversionError:
-      gauge("foo_bar").inc()
+  test "alternative API":
+    counter("one_off_counter").inc()
+    check(counter("one_off_counter").value == 1)
+    counter("one_off_counter").inc(0.5)
+    check(counter("one_off_counter").value == 1.5)
+    # confusing, but allowed
+    check gauge("one_off_counter").value == 0
 
   test "exceptions":
     proc f(switch: bool) =
@@ -109,7 +103,12 @@ suite "gauge":
     check(myGauge.value == 9.5)
     myGauge.set(1)
     check(myGauge.value == 1)
-    check(gauge("myGauge", registry = registry).value == 1)
+
+  test "alternative API":
+    gauge("one_off_gauge").set(1)
+    check(gauge("one_off_gauge").value == 1)
+    gauge("one_off_gauge").inc(0.5)
+    check(gauge("one_off_gauge").value == 1.5)
 
   test "in progress":
     myGauge.trackInProgress:


### PR DESCRIPTION
- retrieving collectors by name string: `counter("foo").inc()` and
  `gauge("bar").set(2)`, with implicit object creation
- cleanup benchmarks and add their compilation to the "test" task