### PR TITLE
add default collectors providing process and Nim runtime info

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ nimble install https://github.com/status-im/nim-metrics@#master
 
 ## Usage
 
-To enable metrics, compile your code with `-d:metrics`. You also need `--threads:on` for some atomic operations to work.
+To enable metrics, compile your code with `-d:metrics`. You also need `--threads:on` for atomic operations to work.
 
 ## Contributing
 

--- a/metrics.nimble
+++ b/metrics.nimble
@@ -17,24 +17,25 @@ proc buildBinary(name: string, srcDir = "./", params = "", lang = "c") =
   var extra_params = params
   for i in 2..<paramCount():
     extra_params &= " " & paramStr(i)
-  exec "nim " & lang & " --out:./build/" & name & " " & extra_params & " " & srcDir & name & ".nim"
+  exec "nim " & lang & " --out:./build/" & name & " -f --skipParentCfg " & extra_params & " " & srcDir & name & ".nim"
 
 proc test(name: string) =
-  buildBinary name, "tests/", "-f -r -d:metrics"
+  buildBinary name, "tests/", "-r -d:metrics --threads:on"
 
 proc bench(name: string) =
-  buildBinary name, "benchmarks/", "-f -r -d:metrics -d:release"
+  buildBinary name, "benchmarks/", "-r -d:metrics --threads:on -d:release"
 
 ### tasks
 task test, "Main tests":
   # build it with metrics disabled, first
-  buildBinary "main_tests", "tests/", "-f"
+  buildBinary "main_tests", "tests/"
+  buildBinary "main_tests", "tests/", "--threads:on"
   test "main_tests"
-  buildBinary "bench_collectors", "benchmarks/", "-f"
-  buildBinary "bench_collectors", "benchmarks/", "-f -d:metrics"
+  buildBinary "bench_collectors", "benchmarks/"
+  buildBinary "bench_collectors", "benchmarks/", "-d:metrics --threads:on"
 
 task test_chronicles, "Chronicles tests":
-  buildBinary "chronicles_tests", "tests/", "-f"
+  buildBinary "chronicles_tests", "tests/"
   test "chronicles_tests"
 
 task benchmark, "Run benchmarks":

--- a/nim.cfg
+++ b/nim.cfg
@@ -1,2 +1,0 @@
---threads:on # needed by atomic operations
-

--- a/tests/chronicles_tests.nim
+++ b/tests/chronicles_tests.nim
@@ -33,4 +33,5 @@ suite "logging":
           for metric in metrics:
             info "metric", metric
     info "registry", registry
+    info "default registry", defaultRegistry
 


### PR DESCRIPTION
- avoid a hidden type cast of registered collectors by using generics
- decouple the test suite from Nim config files in parent dirs
- add test compilation without "--threads:on"