### PR TITLE
Workaround for ARMv6

### DIFF
--- a/metrics.nim
+++ b/metrics.nim
@@ -4,6 +4,10 @@
 #   * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
+when defined(arm):
+  # ARMv6 workaround - TODO upstream to Nim atomics
+  {.passl:"-latomic".}
+
 import algorithm, hashes, locks, net, os, random, re, sequtils, sets, strutils, tables, times
 
 type


### PR DESCRIPTION
Error

```
[NimScript] exec: nim c --out:./build/all_tests -r -d:release -d:chronicles_log_level=ERROR --verbosity:0 --hints:off --warnings:off -d:usePcreH
eader --passL:"-lpcre" tests/all_tests.nim                                                                                                      
/usr/bin/ld: nimcache/release/all_tests/metrics_metrics.c.o: in function `setGauge_TfFRl69aEiBDwcdgzchxbOQ':                                    
metrics_metrics.c:(.text+0x37c0): undefined reference to `__atomic_store_8'                                                                     
/usr/bin/ld: metrics_metrics.c:(.text+0x37f0): undefined reference to `__atomic_store_8'                                                        
collect2: error: ld returned 1 exit status                                                                                                      
Error: execution of an external program failed: 'gcc   -o
```

GCC
```
$  gcc -v
Using built-in specs.
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/arm-linux-gnueabihf/8/lto-wrapper
Target: arm-linux-gnueabihf
Configured with: ../src/configure -v --with-pkgversion='Raspbian 8.3.0-6+rpi1' --with-bugurl=file:///usr/share/doc/gcc-8/README.Bugs --enable-la
nguages=c,ada,c++,go,d,fortran,objc,obj-c++ --prefix=/usr --with-gcc-major-version-only --program-suffix=-8 --program-prefix=arm-linux-gnueabihf
- --enable-shared --enable-linker-build-id --libexecdir=/usr/lib --without-included-gettext --enable-threads=posix --libdir=/usr/lib --enable-nl
s --enable-bootstrap --enable-clocale=gnu --enable-libstdcxx-debug --enable-libstdcxx-time=yes --with-default-libstdcxx-abi=new --enable-gnu-uni
que-object --disable-libitm --disable-libquadmath --disable-libquadmath-support --enable-plugin --with-system-zlib --with-target-system-zlib --e
nable-objc-gc=auto --enable-multiarch --disable-sjlj-exceptions --with-arch=armv6 --with-fpu=vfp --with-float=hard --disable-werror --enable-che
cking=release --build=arm-linux-gnueabihf --host=arm-linux-gnueabihf --target=arm-linux-gnueabihf
Thread model: posix
gcc version 8.3.0 (Raspbian 8.3.0-6+rpi1)
```