### PR TITLE
use the "weak" version of atomicCompareExchange()

### DIFF
--- a/metrics.nim
+++ b/metrics.nim
@@ -64,7 +64,9 @@ when defined(metrics):
     while true:
       atomicLoad(cast[ptr int64](dest), cast[ptr int64](oldVal.addr), ATOMIC_SEQ_CST)
       newVal = oldVal + amount
-      if atomicCompareExchange(cast[ptr int64](dest), cast[ptr int64](oldVal.addr), cast[ptr int64](newVal.addr), false, ATOMIC_SEQ_CST, ATOMIC_SEQ_CST):
+      # the "weak" version is safe in a loop and it's more efficient than the
+      # "strong" version that uses a loop of its own (specially on ARM)
+      if atomicCompareExchange(cast[ptr int64](dest), cast[ptr int64](oldVal.addr), cast[ptr int64](newVal.addr), weak = true, ATOMIC_SEQ_CST, ATOMIC_SEQ_CST):
         break
 
   template processHelp*(help: string): string =
@@ -331,7 +333,7 @@ template countExceptions*(counter: Counter | type IgnoredCollector, typ: typedes
     try:
       body
     except typ:
-      counter.inc(labelValues = labelValues)
+      counter.inc(1, labelValues)
       raise
   else:
     body
@@ -470,9 +472,9 @@ proc setToCurrentTime*(gauge: Gauge | type IgnoredCollector, labelValues: Labels
 
 template trackInProgress*(gauge: Gauge | type IgnoredCollector, labelValues: LabelsParam, body: untyped) =
   when defined(metrics) and gauge is not IgnoredCollector:
-    gauge.inc(labelValues = labelValues)
+    gauge.inc(1, labelValues)
     body
-    gauge.dec(labelValues = labelValues)
+    gauge.dec(1, labelValues)
   else:
     body
 
@@ -489,7 +491,7 @@ template time*(gauge: Gauge | type IgnoredCollector, labelValues: LabelsParam, b
   when defined(metrics) and gauge is not IgnoredCollector:
     let start = times.toUnix(getTime())
     body
-    gauge.set(times.toUnix(getTime()) - start, labelValues = labelValues)
+    gauge.set(times.toUnix(getTime()) - start, labelValues)
   else:
     body
 
@@ -587,7 +589,7 @@ template time*(collector: Summary | Histogram, labelValues: LabelsParam, body: u
   when defined(metrics):
     let start = times.toUnix(getTime())
     body
-    collector.observe(times.toUnix(getTime()) - start, labelValues = labelValues)
+    collector.observe(times.toUnix(getTime()) - start, labelValues)
   else:
     body
 

--- a/metrics.nimble
+++ b/metrics.nimble
@@ -15,8 +15,10 @@ proc buildBinary(name: string, srcDir = "./", params = "", lang = "c") =
   if not dirExists "build":
     mkDir "build"
   var extra_params = params
-  for i in 2..<paramCount():
-    extra_params &= " " & paramStr(i)
+  if paramStr(1) != "e":
+    # we're under Nim, not Nimble
+    for i in 2..<paramCount():
+      extra_params &= " " & paramStr(i)
   exec "nim " & lang & " --out:./build/" & name & " -f --skipParentCfg " & extra_params & " " & srcDir & name & ".nim"
 
 proc test(name: string) =

--- a/metrics/chronicles_support.nim
+++ b/metrics/chronicles_support.nim
@@ -6,10 +6,11 @@
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
 from chronicles import formatIt, expandIt
-import sets, tables,
-      ../metrics
+import ../metrics
 
 when defined(metrics):
+  import tables
+
   formatIt(Metric):
     it.toText(showTimestamp = false)
 

--- a/tests/chronicles_tests.nim
+++ b/tests/chronicles_tests.nim
@@ -5,8 +5,11 @@
 #   * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import chronicles, tables, unittest,
+import chronicles, unittest,
       ../metrics, ../metrics/chronicles_support
+
+when defined(metrics):
+  import tables
 
 suite "logging":
   test "info":

--- a/tests/main_tests.nim
+++ b/tests/main_tests.nim
@@ -5,7 +5,7 @@
 #   * Apache License, Version 2.0, ([LICENSE-APACHE](LICENSE-APACHE) or http://www.apache.org/licenses/LICENSE-2.0)
 # at your option. This file may not be copied, modified, or distributed except according to those terms.
 
-import net, os, strutils, unittest,
+import net, os, unittest,
       ../metrics
 
 when defined(metrics):


### PR DESCRIPTION
This one is dedicated to you, @mratsim, for noticing that the weak variant is more efficient on ARM.

The rest of the diff is for fixing some weird Nim-1.0.2 breakage that mistakenly gensyms template
parameter names (so `counter.inc(labelValues = labelValues)` ended up as ```inc(myCounter, labelValues`gensym605630 = labelValues`gensym605630)```) - probably https://github.com/nim-lang/Nim/issues/12121