### PR TITLE
update system metrics from the main thread

### DIFF
--- a/tests/main_tests.nim
+++ b/tests/main_tests.nim
@@ -8,6 +8,8 @@ import net, os, unittest,
       ../metrics
 
 when defined(metrics):
+  import times
+
   addExportBackend(
     metricProtocol = STATSD,
     netProtocol = UDP,
@@ -336,4 +338,20 @@ suite "registry":
     expect RegistrationError:
       declareCounter duplicate_counter, "duplicate counter"
       duplicate_counter.inc()
+
+suite "system metrics":
+  test "change update interval":
+    when defined(metrics):
+      declareGauge myGauge, "my gauge"
+      myGauge.set(1)
+      # echo defaultRegistry
+      echo getSystemMetricsUpdateInterval()
+      setSystemMetricsUpdateInterval(initDuration(seconds = 1))
+      echo getSystemMetricsUpdateInterval()
+      sleep(2)
+      myGauge.set(2)
+      # echo defaultRegistry
+      echo getSystemMetricsAutomaticUpdate()
+      setSystemMetricsAutomaticUpdate(false)
+      updateSystemMetrics()
 


### PR DESCRIPTION
Fixes https://github.com/status-im/nim-metrics/issues/38

System metrics are now automatically updated when a user-defined metric is changed, in the main thread, if at least 10 seconds passed since the last update. The interval is configurable.

This automation can be disabled, if the API user wants to update system metrics with better regularity, from some event loop.