### PR TITLE
per-thread GC metrics

### DIFF
--- a/README.md
+++ b/README.md
@@ -350,9 +350,10 @@ process_max_fds
 process_virtual_memory_bytes
 process_resident_memory_bytes
 process_start_time_seconds
-nim_gc_mem_bytes
-nim_gc_mem_occupied_bytes
+nim_gc_mem_bytes[thread_id]
+nim_gc_mem_occupied_bytes[thread_id]
 nim_gc_heap_instance_occupied_bytes[type_name]
+nim_gc_heap_instance_occupied_summed_bytes
 ```
 
 The `process_*` metrics are only available on Linux, for now.
@@ -384,7 +385,12 @@ metrics yourself.
 setSystemMetricsAutomaticUpdate(false)
 # somewhere in your event loop, at an interval of your choice
 updateSystemMetrics()
+updateThreadMetrics()
 ```
+
+Those metrics with with a "thread\_id" label are thread-specific metrics. The
+automatic update only covers thread metrics for the main thread. You'll have to
+call `updateThreadMetrics()` by yourself for any other thread you care about.
 
 Screenshot of [Grafana showing data from Prometheus that pulls it from Nimbus which uses nim-metrics](https://github.com/status-im/nimbus-eth1/#metric-visualisation):
 


### PR DESCRIPTION
Those two GC metrics that show thread-specific data got a "thread_id" label and an `updateThreadMetrics()` proc, extracted from `updateSystemMetrics()` so it can be called in multiple threads.

I also added a new metric - `nim_gc_heap_instance_occupied_summed_bytes` - which sums up all the sizes we get from `dumpHeapInstances()`, but it turns out to be smaller than `nim_gc_mem_occupied_bytes` in the main thread:

```text
$ curl -sS http://127.0.0.1:8008/metrics | grep nim_gc | grep -Ev 'created|type_name|^#'
nim_gc_mem_bytes{thread_id="15016"} 1582231552.0
nim_gc_mem_occupied_bytes{thread_id="15016"} 676859760.0
nim_gc_heap_instance_occupied_summed_bytes 634171659.0
```

Do we want to keep it?