### PR TITLE
Do not set conflicting `--mm` params

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -166,5 +166,5 @@ jobs:
           nimble install -y --depsOnly
           nimble install -y chronicles@#head
           nimble install -y unittest2
-          env NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test
-          env NIMFLAGS="${NIMFLAGS} --mm:refc" nimble test_chronicles
+          nimble test
+          nimble test_chronicles


### PR DESCRIPTION
The `.nimble` file already ensures that both `--mm:refc` and `--mm:orc` are passed. If we also set it in `ci.yml` then both options are passed, including the case where they are conflicting.