### PR TITLE
make chronicles work with metrics logging

### DIFF
--- a/metrics/chronicles_support.nim
+++ b/metrics/chronicles_support.nim
@@ -52,6 +52,7 @@ when defined(metrics):
             )
           )
     )
+    res
 
   formatIt(Registry):
     it.toLog


### PR DESCRIPTION
why:
  missing return code in formatter