### PR TITLE
Remove `_created` from gauges

### DIFF
--- a/metrics.nim
+++ b/metrics.nim
@@ -690,12 +690,6 @@ when defined(metrics):
     result =
       @[
         Metric(name: name, labels: @labels, labelValues: labelValues),
-        Metric(
-          name: name & "_created",
-          labels: @labels,
-          labelValues: labelValues,
-          value: getTime().toUnix().float64,
-        )
       ]
 
   proc newGauge*(


### PR DESCRIPTION
Per other prom client libs, only counters/summaries/histograms should have a `_created` sample - this also applies to openmetrics.