### PR TITLE
clean up per-thread metrics

### DIFF
--- a/tests/main_tests.nim
+++ b/tests/main_tests.nim
@@ -117,8 +117,7 @@ suite "counter":
     check lCounter2.value(labelValues2) == 1
 
   test "sample rate":
-    declareCounter sCounter,
-      "counter with a sample rate set", registry = registry, sampleRate = 0.5
+    declareCounter sCounter, "counter with a sample rate set", registry = registry
     sCounter.inc()
     # No sampling done on our side, just in sending the increments to a StatsD server
     check sCounter.value == 1


### PR DESCRIPTION
The existing implementation was confused about how running a proc in a thread works - just because there's a pointer involved doesn't mean that a thread-specific version of a proc is used. For the registration to work, one would have to extract a pointer to the per-thread heap that the nim GC uses which is not trivial.