### PR TITLE
allow creating labels from different threads

### DIFF
--- a/metrics.nim
+++ b/metrics.nim
@@ -17,25 +17,33 @@ when defined(metricsTest):
 else:
   {.pragma: testOnly, deprecated: "slow helpers used for tests only".}
 
-import std/[locks, monotimes, os, sets, tables, times]
+import std/[locks, monotimes, os, sets, times], metrics/shseq
+
+export shseq
 
 when defined(metrics):
   import std/[algorithm, hashes, strutils, sequtils], stew/ptrops, metrics/common
 
-  export tables # for custom collectors that need to work with the "Metrics" type
-
 type
-  LabelKey = object
-    # Helper type to work around the lack of heterogenous key support in `Table`
-    data: seq[string]
-    refs: ptr UncheckedArray[string]
-    refslen: int
+  CStringArray = object
+    items: ptr UncheckedArray[cstring]
+    len: int
+
+  StringView = object
+    items: ptr UncheckedArray[string]
+    len: int
+
+  LabelKey = object # Helper type for heterogeneous lookups in the keys table
+    data: CStringArray
+    refs: StringView
 
   Metric* = object
-    name*: string
+    # Metric needs to be trivial because it's stored in a cross-thread seq and
+    # therefore cannot use GC types
+    name*: cstring
     value*: float64
-    labels*: seq[string]
-    labelValues*: seq[string]
+    labels*: CStringArray
+    labelValues*: CStringArray
     timestamp*: Time
 
   MetricHandler* = proc(
@@ -55,11 +63,10 @@ type
     typ*: string
     labels*: seq[string]
     timestamp*: bool ## Whether or not we're collecting timestamps for this collector
-    creationThreadId*: int
 
   SimpleCollector* = ref object of Collector
-    metricKeys*: Table[LabelKey, int]
-    metrics*: seq[seq[Metric]]
+    metricKeys*: ShSeq[LabelKey]
+    metrics*: ShSeq[ShSeq[Metric]]
 
   IgnoredCollector* = object
 
@@ -72,6 +79,7 @@ type
   Registry* = ref object of RootObj
     lock*: Lock
     collectors*: OrderedSet[Collector]
+    creationThreadId*: int
 
   RegistrationError* = object of CatchableError
 
@@ -80,24 +88,73 @@ type
 #########
 
 when defined(metrics):
-  template values(key: LabelKey): openArray[string] =
-    if key.refslen > 0:
-      key.refs.toOpenArray(0, key.refslen - 1)
-    else:
-      key.data
+  # TODO the shared memory allocated below is never freed - this is fine as long
+  #      as registries / metrics never go away (ie they're globals whose lifetime
+  #      matches that of the application) but to do things properly, this shared
+  #      memory should be released at some point
+  from system/ansi_c import c_strcmp
+  proc createShared(_: type cstring, v: string): cstring =
+    # Create a shared-memory copy of the given string that later must be manually
+    # deallocated
+    var p = cast[cstring](createSharedU(char, v.len + 1))
+    copyMem(p, addr v[0], v.len)
+    p[v.len] = '\0'
+    p
 
-  proc hash(key: LabelKey): Hash =
-    hash(key.values)
+  proc createShared(_: type CStringArray, v: openArray[string]): CStringArray =
+    if v.len > 0:
+      var p = cast[ptr UncheckedArray[cstring]](createSharedU(cstring, v.len))
+      for i in 0 ..< v.len:
+        p[i] = cstring.createShared(v[i])
+
+      CStringArray(items: p, len: v.len)
+    else:
+      CStringArray()
+
+  proc `[]`(s: CStringArray, i: int): cstring =
+    s.items[i]
+
+  proc toStringSeq(v: CStringArray): seq[string] =
+    for i in 0 ..< v.len:
+      result.add $v[i]
+
+  proc len(a: LabelKey): int =
+    if a.data.len > 0: a.data.len else: a.refs.len
+
+  template `[]`(a: LabelKey, i: int): cstring =
+    if a.data.len > 0:
+      a.data[i]
+    else:
+      cstring(a.refs.items[i])
 
   proc `==`(a, b: LabelKey): bool =
-    a.values == b.values
+    if a.len == b.len:
+      for i in 0 ..< a.len:
+        if c_strcmp(a[i], b[i]) != 0:
+          return false
+      true
+    else:
+      false
+
+  proc cmp(a, b: LabelKey): int =
+    # TODO https://github.com/nim-lang/Nim/issues/24941
+    for i in 0 ..< min(a.len, b.len):
+      let c = c_strcmp(a[i], b[i])
+      if c != 0:
+        return c
+
+    cmp(a.len, b.len)
 
   proc init(T: type LabelKey, values: openArray[string]): T =
-    LabelKey(data: @values)
+    # TODO Avoid leaking this shared array, in case we were to clean up the
+    #      registry
+    LabelKey(data: CStringArray.createShared(values))
 
   proc view(T: type LabelKey, values: openArray[string]): T =
     # TODO some day, we might get view types - until then..
-    LabelKey(refs: baseAddr(values).makeUncheckedArray(), refslen: values.len())
+    LabelKey(
+      refs: StringView(items: baseAddr(values).makeUncheckedArray(), len: values.len())
+    )
 
   proc toMilliseconds*(time: times.Time): int64 =
     convert(Seconds, Milliseconds, time.toUnix()) +
@@ -115,14 +172,11 @@ when defined(metrics):
   proc processType(name, typ: string): string =
     "# TYPE " & name & " " & typ & "\n"
 
-  template processLabelValue(labelValue: string): string =
-    labelValue.multiReplace([("\\", "\\\\"), ("\n", "\\n"), ("\"", "\\\"")])
-
-  proc addText(
+  proc addText*(
       res: var string,
-      name: string,
+      name: auto,
       value: float64,
-      labels, labelValues: openArray[string],
+      labels, labelValues: auto,
       timestamp: Time,
   ) =
     # A bit convoluted to mostly avoid pointless memory allocations - there's no
@@ -130,13 +184,22 @@ when defined(metrics):
     res.add name
     if labels.len > 0:
       res.add('{')
-      for i in 0 .. labels.high:
+      for i in 0 ..< labels.len:
         if i > 0:
           res.add ","
         res.add labels[i]
         res.add "=\""
         if labelValues.len > i:
-          res.add labelValues[i]
+          for c in labelValues[i]:
+            case c
+            of '\\':
+              res.add "\\\\"
+            of '\n':
+              res.add "\\\n"
+            of '"':
+              res.add "\\\""
+            else:
+              res.add c
         res.add "\""
       res.add('}')
     res.add(" ")
@@ -201,7 +264,7 @@ when defined(metrics):
   template withLabelValues(
       collector: SimpleCollector,
       labelValues: openArray[string],
-      metricSym, body, construct: untyped,
+      metricSym, keySym, body, construct: untyped,
   ) =
     if labelValues.len > 0 and labelValues.len != collector.labels.len:
       printError(
@@ -210,25 +273,18 @@ when defined(metrics):
       )
     else:
       withLock(collector.lock):
-        collector.metricKeys.withValue(LabelKey.view(labelValues), metricsIdx):
-          template metricSym(): untyped =
-            collector.metrics[metricsIdx[]]
+        let pos =
+          collector.metricKeys.data().lowerBound(LabelKey.view(labelValues), cmp)
+        if pos == collector.metricKeys.len or
+            collector.metricKeys[pos] != LabelKey.view(labelValues):
+          let keySym = LabelKey.init(labelValues)
+          collector.metricKeys.insert(keySym, pos)
+          collector.metrics.insert(construct, pos)
 
-          body
-        do:
-          if collector.creationThreadId != getThreadId():
-            printError(
-              "New label values must be added from same thread as the metric was created from - observation dropped: " &
-                collector.name
-            )
-          else:
-            collector.metrics.add construct
-            collector.metricKeys[LabelKey.init(labelValues)] = collector.metrics.high
-            collector.metricKeys.withValue(LabelKey.view(labelValues), metricsIdx):
-              template metricSym(): untyped =
-                collector.metrics[metricsIdx[]]
+        template metricSym(): untyped =
+          collector.metrics[pos]
 
-              body
+        body
 
   method hash*(collector: Collector): Hash {.base.} =
     result = result !& collector.name.hash
@@ -248,7 +304,11 @@ when defined(metrics):
 
   proc call(output: MetricHandler, metric: Metric) =
     output(
-      metric.name, metric.value, metric.labels, metric.labelValues, metric.timestamp
+      $metric.name,
+      metric.value,
+      toStringSeq(metric.labels),
+      toStringSeq(metric.labelValues),
+      metric.timestamp,
     )
 
   method collect*(collector: Collector, output: MetricHandler) {.base.} =
@@ -257,8 +317,8 @@ when defined(metrics):
   method collect*(collector: SimpleCollector, output: MetricHandler) =
     {.warning[LockLevel]: off.}
     withLock(collector.lock):
-      for key, idx in collector.metricKeys:
-        for metric in collector.metrics[idx]:
+      for family in collector.metrics:
+        for metric in family:
           call(output, metric)
 
   proc collect*(registry: Registry, output: MetricHandler) =
@@ -290,29 +350,35 @@ proc `$`*(collector: type IgnoredCollector): string =
   ""
 
 when defined(metrics):
+  template localGlobal(init: untyped): untyped =
+    # https://github.com/status-im/nim-metrics/pull/5#discussion_r304687474
+    # https://github.com/nim-lang/Nim/issues/24940
+    var res {.global.}: typeof(init)
+    if isNil(res):
+      res = init
+    res
+
   proc valueImpl*(
-      collector: Collector, labelValuesParam: openArray[string] = []
+      collector: Collector, labelValues: openArray[string] = []
   ): float64 {.gcsafe, raises: [KeyError].} =
     var res = NaN
     # Don't access the "metrics" field directly, so we can support custom
     # collectors.
     {.gcsafe.}:
-      let lv = @labelValuesParam.mapIt(it.processLabelValue())
       proc findMetric(
           name: string,
           value: float64,
           labels, labelValues: openArray[string],
           timestamp: Time,
       ) =
-        if res != res and labelValues == lv:
+        if res != res and labelValues == labelValues:
           res = value
 
       collect(collector, findMetric)
       if res != res: # NaN
         raise newException(
           KeyError,
-          "No such metric for this collector (label values = " & $(@labelValuesParam) &
-            ").",
+          "No such metric for this collector (label values = " & $(@labelValues) & ").",
         )
     res
 
@@ -334,7 +400,7 @@ proc valueByNameInternal*(
 ): float64 {.raises: [ValueError].} =
   when defined(metrics) and collector is not IgnoredCollector:
     var res = NaN
-    let allLabelValues = labelValues.mapIt(it.processLabelValue()) & @extraLabelValues
+    let allLabelValues = @labelValues & @extraLabelValues
     proc findMetric(
         name: string,
         value: float64,
@@ -371,6 +437,7 @@ proc newRegistry*(): Registry =
   when defined(metrics):
     new(result)
     result.lock.initLock()
+    result.creationThreadId = getThreadId()
 
 # needs to be {.global.} because of the alternative API's usage of {.global.} collector vars
 let defaultRegistry* {.global.} = newRegistry()
@@ -381,6 +448,13 @@ proc register*[T](
     collector: T, registry = defaultRegistry
 ) {.raises: [RegistrationError].} =
   when defined(metrics):
+    # TODO To relax this, collectors can no longer be `ref object`
+    if registry.creationThreadId != getThreadId():
+      printError(
+        "New collectors / metrics must be added from same thread as the registry was created from: " &
+          collector.name
+      )
+
     withLock registry.lock:
       if collector in registry.collectors:
         raise newException(
@@ -449,7 +523,6 @@ when defined(metrics):
       typ: processType(name, standardType),
         # Prometheus does not support a non-standard value here
       labels: @labels,
-      creationThreadId: getThreadId(),
       timestamp: timestamp,
     )
     result.lock.initLock()
@@ -472,18 +545,23 @@ when defined(metrics):
 
 when defined(metrics):
   proc newCounterMetrics(
-      name: string, labels, labelValues: openArray[string]
-  ): seq[Metric] =
-    let labelValues = labelValues.mapIt(it.processLabelValue())
-    @[
-      Metric(name: name & "_total", labels: @labels, labelValues: labelValues),
-      Metric(
-        name: name & "_created",
-        labels: @labels,
-        labelValues: labelValues,
-        value: getTime().toUnix().float64,
-      ),
-    ]
+      name: string, labels, labelValues: CStringArray
+  ): ShSeq[Metric] =
+    ShSeq.init(
+      [
+        Metric(
+          name: cstring.createShared(name & "_total"),
+          labels: labels,
+          labelValues: labelValues,
+        ),
+        Metric(
+          name: cstring.createShared(name & "_created"),
+          labels: labels,
+          labelValues: labelValues,
+          value: getTime().toUnix().float64,
+        ),
+      ]
+    )
 
   # don't document this one, even if we're forced to make it public, because it
   # won't work when all (or some) collectors are disabled
@@ -496,8 +574,8 @@ when defined(metrics):
   ): Counter {.raises: [ValueError, RegistrationError].} =
     result = Counter.newCollector(name, help, labels, registry, "counter", timestamp)
     if labels.len == 0:
-      result.metrics.add newCounterMetrics(name, labels, labels)
-      result.metricKeys[LabelKey.init(labels)] = result.metrics.high()
+      result.metrics.add newCounterMetrics(name, CStringArray(), CStringArray())
+      result.metricKeys.add LabelKey.init(labels)
 
   proc incCounter(counter: Counter, amount: float64, labelValues: openArray[string]) =
     if amount < 0:
@@ -508,11 +586,13 @@ when defined(metrics):
       return
 
     let timestamp = counter.now()
-    withLabelValues(counter, labelValues, valueSym):
+    withLabelValues(counter, labelValues, valueSym, keySym):
       valueSym[0].value += amount
       valueSym[0].timestamp = timestamp
     do:
-      newCounterMetrics(counter.name, counter.labels, labelValues)
+      newCounterMetrics(
+        counter.name, CStringArray.createShared(counter.labels), keySym.data
+      )
 
     updateSystemMetrics()
 
@@ -548,7 +628,6 @@ template declarePublicCounter*(
 
 #- alternative API (without support for custom help strings, labels or custom registries)
 #- different collector types with the same names are allowed
-#- don't mark this proc as {.inline.} because it's incompatible with {.global.}: https://github.com/status-im/nim-metrics/pull/5#discussion_r304687474
 when defined(metrics):
   proc counter*(
       name: static string
@@ -556,8 +635,7 @@ when defined(metrics):
     # This {.global.} var assignment is lifted from the procedure and placed in a
     # special module init section that's guaranteed to run only once per program.
     # Calls to this proc will just return the globally initialised variable.
-    var res {.global.} = newCounter(name, "")
-    return res
+    localGlobal(newCounter(name, ""))
 
 else:
   template counter*(name: static string): untyped =
@@ -615,11 +693,8 @@ template countExceptions*(counter: Counter | type IgnoredCollector, body: untype
 #########
 
 when defined(metrics):
-  proc newGaugeMetrics(
-      name: string, labels, labelValues: openArray[string]
-  ): seq[Metric] =
-    let labelValues = labelValues.mapIt(it.processLabelValue())
-    result = @[Metric(name: name, labels: @labels, labelValues: labelValues)]
+  proc newGaugeMetrics(name: string, labels, labelValues: CStringArray): ShSeq[Metric] =
+    ShSeq.init([Metric(name: name, labels: labels, labelValues: labelValues)])
 
   proc newGauge*(
       name: string,
@@ -630,17 +705,17 @@ when defined(metrics):
   ): Gauge {.raises: [ValueError, RegistrationError].} =
     result = Gauge.newCollector(name, help, labels, registry, "gauge", timestamp)
     if labels.len == 0:
-      result.metrics.add newGaugeMetrics(name, labels, labels)
-      result.metricKeys[LabelKey.init(labels)] = result.metrics.high()
+      result.metrics.add newGaugeMetrics(name, CStringArray(), CStringArray())
+      result.metricKeys.add LabelKey.init(labels)
 
   proc incGauge(gauge: Gauge, amount: float64, labelValues: openArray[string]) =
     let timestamp = gauge.now()
 
-    withLabelValues(gauge, labelValues, valueSym):
+    withLabelValues(gauge, labelValues, valueSym, keySym):
       valueSym[0].value += amount
       valueSym[0].timestamp = timestamp
     do:
-      newGaugeMetrics(gauge.name, gauge.labels, labelValues)
+      newGaugeMetrics(gauge.name, CStringArray.createShared(gauge.labels), keySym.data)
 
     updateSystemMetrics()
 
@@ -652,12 +727,11 @@ when defined(metrics):
   ) =
     let timestamp = gauge.now()
 
-    withLabelValues(gauge, labelValues, valueSym):
+    withLabelValues(gauge, labelValues, valueSym, keySym):
       valueSym[0].value = value.float64
-      if gauge.timestamp:
-        valueSym[0].timestamp = getTime()
+      valueSym[0].timestamp = timestamp
     do:
-      newGaugeMetrics(gauge.name, gauge.labels, labelValues)
+      newGaugeMetrics(gauge.name, CStringArray.createShared(gauge.labels), keySym.data)
 
     if doUpdateSystemMetrics:
       updateSystemMetrics()
@@ -679,8 +753,7 @@ template declareGauge*(
 # alternative API
 when defined(metrics):
   proc gauge*(name: static string): Gauge {.raises: [ValueError, RegistrationError].} =
-    var res {.global.} = newGauge(name, "") # lifted line
-    return res
+    localGlobal(newGauge(name, ""))
 
 else:
   template gauge*(name: static string): untyped =
@@ -776,19 +849,28 @@ template time*(
 
 when defined(metrics):
   proc newSummaryMetrics(
-      name: string, labels, labelValues: openArray[string]
-  ): seq[Metric] =
-    let labelValues = labelValues.mapIt(it.processLabelValue())
-    @[
-      Metric(name: name & "_sum", labels: @labels, labelValues: labelValues),
-      Metric(name: name & "_count", labels: @labels, labelValues: labelValues),
-      Metric(
-        name: name & "_created",
-        labels: @labels,
-        labelValues: labelValues,
-        value: getTime().toUnix().float64,
-      ),
-    ]
+      name: string, labels, labelValues: CStringArray
+  ): ShSeq[Metric] =
+    ShSeq.init(
+      [
+        Metric(
+          name: cstring.createShared(name & "_sum"),
+          labels: labels,
+          labelValues: labelValues,
+        ),
+        Metric(
+          name: cstring.createShared(name & "_count"),
+          labels: labels,
+          labelValues: labelValues,
+        ),
+        Metric(
+          name: cstring.createShared(name & "_created"),
+          labels: labels,
+          labelValues: labelValues,
+          value: getTime().toUnix().float64,
+        ),
+      ]
+    )
 
   proc newSummary*(
       name: string,
@@ -800,21 +882,23 @@ when defined(metrics):
     validateLabels(labels, invalidLabelNames = ["quantile"])
     result = Summary.newCollector(name, help, labels, registry, "summary", timestamp)
     if labels.len == 0:
-      result.metrics.add newSummaryMetrics(name, labels, labels)
-      result.metricKeys[LabelKey.init(labels)] = result.metrics.high()
+      result.metrics.add newSummaryMetrics(name, CStringArray(), CStringArray())
+      result.metricKeys.add LabelKey.init(labels)
 
   proc observeSummary(
       summary: Summary, amount: float64, labelValues: openArray[string]
   ) =
     let timestamp = summary.now()
 
-    withLabelValues(summary, labelValues, valueSym):
+    withLabelValues(summary, labelValues, valueSym, keySym):
       valueSym[0].value += amount # _sum
       valueSym[0].timestamp = timestamp
       valueSym[1].value += 1.float64 # _count
       valueSym[1].timestamp = timestamp
     do:
-      newSummaryMetrics(summary.name, summary.labels, labelValues)
+      newSummaryMetrics(
+        summary.name, CStringArray.createShared(summary.labels), keySym.data
+      )
 
 template declareSummary*(
     identifier: untyped,
@@ -846,8 +930,7 @@ when defined(metrics):
   proc summary*(
       name: static string
   ): Summary {.raises: [ValueError, RegistrationError].} =
-    var res {.global.} = newSummary(name, "") # lifted line
-    return res
+    localGlobal(newSummary(name, ""))
 
 else:
   template summary*(name: static string): untyped =
@@ -882,30 +965,42 @@ const defaultHistogramBuckets* =
   [0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1.0, 2.5, 5.0, 7.5, 10.0, Inf]
 when defined(metrics):
   proc newHistogramMetrics(
-      name: string, labels, labelValues: openArray[string], buckets: seq[float64]
-  ): seq[Metric] =
-    let labelValues = labelValues.mapIt(it.processLabelValue())
-    result =
-      @[
-        Metric(name: name & "_sum", labels: @labels, labelValues: labelValues),
-        Metric(name: name & "_count", labels: @labels, labelValues: labelValues),
+      name: string, labels, labelValues: CStringArray, buckets: seq[float64]
+  ): ShSeq[Metric] =
+    result = ShSeq.init(
+      [
         Metric(
-          name: name & "_created",
-          labels: @labels,
+          name: cstring.createShared(name & "_sum"),
+          labels: labels,
+          labelValues: labelValues,
+        ),
+        Metric(
+          name: cstring.createShared(name & "_count"),
+          labels: labels,
+          labelValues: labelValues,
+        ),
+        Metric(
+          name: cstring.createShared(name & "_created"),
+          labels: labels,
           labelValues: labelValues,
           value: getTime().toUnix().float64,
         ),
       ]
-    var bucketLabels = @labels & "le"
+    )
+    let
+      bucketLabels = CStringArray.createShared(labels.toStringSeq & "le")
+      labelValues = labelValues.toStringSeq()
     for bucket in buckets:
-      var bucketStr = $bucket
-      if bucket == Inf:
-        bucketStr = "+Inf"
+      let bucketStr =
+        if bucket == Inf:
+          "+Inf"
+        else:
+          $bucket
       result.add(
         Metric(
-          name: name & "_bucket",
+          name: cstring.createShared(name & "_bucket"),
           labels: bucketLabels,
-          labelValues: labelValues & bucketStr,
+          labelValues: CStringArray.createShared(@labelValues & bucketStr),
         )
       )
 
@@ -933,14 +1028,16 @@ when defined(metrics):
       Histogram.newCollector(name, help, labels, registry, "histogram", timestamp)
     result.buckets = bucketsSeq
     if labels.len == 0:
-      result.metrics.add newHistogramMetrics(name, labels, labels, bucketsSeq)
-      result.metricKeys[LabelKey.init(labels)] = result.metrics.high()
+      result.metrics.add newHistogramMetrics(
+        name, CStringArray(), CStringArray(), bucketsSeq
+      )
+      result.metricKeys.add LabelKey.init(labels)
 
   proc observeHistogram(
       histogram: Histogram, amount: float64, labelValues: openArray[string]
   ) =
     let timestamp = histogram.now()
-    withLabelValues(histogram, labelValues, valueSym):
+    withLabelValues(histogram, labelValues, valueSym, keySym):
       valueSym[0].value += amount # _sum
       valueSym[0].timestamp = timestamp
       valueSym[1].value += 1.float64 # _count
@@ -954,7 +1051,10 @@ when defined(metrics):
           valueSym[i + 3].timestamp = timestamp
     do:
       newHistogramMetrics(
-        histogram.name, histogram.labels, labelValues, histogram.buckets
+        histogram.name,
+        CStringArray.createShared(histogram.labels),
+        keySym.data,
+        histogram.buckets,
       )
 
 template declareHistogram*(
@@ -993,8 +1093,7 @@ when defined(metrics):
   proc histogram*(
       name: static string
   ): Histogram {.raises: [ValueError, RegistrationError].} =
-    let res {.global.} = newHistogram(name, "") # lifted line
-    return res
+    localGlobal(newHistogram(name, ""))
 
 else:
   template histogram*(name: static string): untyped =
@@ -1135,11 +1234,11 @@ when defined(metrics):
     NimRuntimeInfo.newCollector("nim_runtime_info", "Nim runtime info")
 
   method collect*(collector: NimRuntimeInfo, output: MetricHandler) =
-    let timestamp = collector.now()
     try:
       when defined(nimTypeNames) and declared(dumpHeapInstances):
         # Too high cardinality causes performance issues in Prometheus.
         const labelsLimit = 10
+        let timestamp = collector.now()
         var
           # Higher size than in the loop for adding metrics
           # to avoid missing same name metrics far apart with low values.

--- a/metrics.nim
+++ b/metrics.nim
@@ -97,7 +97,8 @@ when defined(metrics):
     # Create a shared-memory copy of the given string that later must be manually
     # deallocated
     var p = cast[cstring](createSharedU(char, v.len + 1))
-    copyMem(p, addr v[0], v.len)
+    if v.len > 0:
+      copyMem(p, baseAddr v, v.len)
     p[v.len] = '\0'
     p
 

--- a/metrics.nim
+++ b/metrics.nim
@@ -154,7 +154,8 @@ when defined(metrics):
   proc view(T: type LabelKey, values: openArray[string]): T =
     # TODO some day, we might get view types - until then..
     LabelKey(
-      refs: StringArrView(items: baseAddr(values).makeUncheckedArray(), len: values.len())
+      refs:
+        StringArrView(items: baseAddr(values).makeUncheckedArray(), len: values.len())
     )
 
   proc toMilliseconds*(time: times.Time): int64 =
@@ -548,9 +549,7 @@ when defined(metrics):
 ###########
 
 when defined(metrics):
-  proc newCounterMetrics(
-      name: string, labels, labelValues: CStringArr
-  ): ShSeq[Metric] =
+  proc newCounterMetrics(name: string, labels, labelValues: CStringArr): ShSeq[Metric] =
     ShSeq.init(
       [
         Metric(
@@ -852,9 +851,7 @@ template time*(
 ###########
 
 when defined(metrics):
-  proc newSummaryMetrics(
-      name: string, labels, labelValues: CStringArr
-  ): ShSeq[Metric] =
+  proc newSummaryMetrics(name: string, labels, labelValues: CStringArr): ShSeq[Metric] =
     ShSeq.init(
       [
         Metric(

--- a/metrics.nim
+++ b/metrics.nim
@@ -352,6 +352,9 @@ proc `$`*(collector: type IgnoredCollector): string =
 
 when defined(metrics):
   template localGlobal(init: untyped): untyped =
+    when (NimMajor, NimMinor) == (2, 0) and (defined(gcOrc) or defined(gcArc)):
+      {.error: "Globals are too broken in Nim 2.0/ORC/ARC".}
+
     # https://github.com/status-im/nim-metrics/pull/5#discussion_r304687474
     # https://github.com/nim-lang/Nim/issues/24940
     var res {.global.}: typeof(init)

--- a/metrics.nimble
+++ b/metrics.nimble
@@ -36,7 +36,7 @@ task test, "Main tests":
   # build it with metrics disabled, first
   build "", "tests/main_tests"
   build "--threads:on", "tests/main_tests"
-  run "-d:metrics --threads:on", "tests/main_tests"
+  run "-d:metrics --threads:on -d:useSysAssert -d:useGcAssert", "tests/main_tests"
 
   build "", "benchmarks/bench_collectors"
   run "-d:metrics --threads:on", "benchmarks/bench_collectors"

--- a/metrics.nimble
+++ b/metrics.nimble
@@ -29,7 +29,7 @@ proc build(args, path: string) =
 proc run(args, path: string) =
   build args & " --mm:refc -r", path
   if (NimMajor, NimMinor) > (1, 6):
-    build args & " --mm:orc -d:noAlter -r", path
+    build args & " --mm:orc -r", path
 
 ### tasks
 task test, "Main tests":

--- a/metrics/chronicles_support.nim
+++ b/metrics/chronicles_support.nim
@@ -42,15 +42,9 @@ when defined(metrics):
           labelValues: openArray[string],
           timestamp: Time,
       ) =
-        res.add(
-          $Metric(
-            name: name,
-            value: value,
-            labels: @labels,
-            labelValues: @labelValues,
-            timestamp: timestamp,
-          )
-        )
+        var s: string
+        s.addText(name, value, labels, labelValues, timestamp)
+        res.add s
     )
     res
 

--- a/metrics/shseq.nim
+++ b/metrics/shseq.nim
@@ -1,0 +1,79 @@
+# Copyright (c) 2025 Status Research & Development GmbH
+# Licensed and distributed under either of
+#   * MIT license: http://opensource.org/licenses/MIT
+#   * Apache License, Version 2.0: http://www.apache.org/licenses/LICENSE-2.0
+# at your option. This file may not be copied, modified, or distributed except according to those terms.
+
+import std/typetraits
+
+type ShSeq*[T] = object
+  # Sequence whose elements reside in shared memory - only works for copyMem:able types
+  items: ptr UncheckedArray[T]
+  capacity, len: int
+
+proc grow(s: var ShSeq, size: int) =
+  type T = typeof(s).T
+
+  static:
+    doAssert supportsCopyMem(T)
+
+  if size <= s.capacity:
+    return
+
+  var tmp = cast[ptr UncheckedArray[T]](createU(T, size))
+  if s.len > 0:
+    copyMem(addr tmp[0], addr s.items[0], s.len * sizeof(T))
+  s.capacity = size
+  s.items = tmp
+
+proc destroy*(s: var ShSeq) =
+  if not isNil(s.items):
+    deallocShared(s.items)
+    reset(s)
+
+proc init*[T](_: type ShSeq, v: openArray[T]): ShSeq[T] =
+  var s: ShSeq[T]
+  if v.len > 0:
+    s.grow(v.len)
+    copyMem(addr s.items[0], unsafeAddr v[0], v.len * sizeof(T))
+    s.len = v.len
+
+  s
+
+proc add*(s: var ShSeq, v: auto) =
+  if s.len == s.capacity:
+    s.grow(max(64, s.len + s.len div 2))
+  s.items[s.len] = v
+  s.len += 1
+
+func `[]`*(s: ShSeq, i: int): lent s.T =
+  doAssert i >= 0 and i < s.len, "Bounds check"
+  s.items[i]
+
+func `[]`*(s: var ShSeq, i: int): var s.T =
+  doAssert i >= 0 and i < s.len, "Bounds check"
+  s.items[i]
+
+proc insert*(s: var ShSeq, v: auto, pos: int) =
+  type T = typeof(s).T
+
+  doAssert pos >= 0 and pos <= s.len, "Bounds check"
+
+  if s.len == s.capacity:
+    s.grow(max(64, s.len + s.len div 2))
+
+  if pos < s.len:
+    moveMem(addr s.items[pos + 1], addr s.items[pos], (s.len - pos) * sizeof(T))
+
+  s.items[pos] = v
+  s.len += 1
+
+template len*(s: ShSeq): int =
+  s.len
+
+template data*(s: ShSeq): openArray =
+  s.items.toOpenArray(0, s.len - 1)
+
+iterator items*(s: ShSeq): lent s.T =
+  for i in 0 ..< s.len:
+    yield s[i]

--- a/metrics/shseq.nim
+++ b/metrics/shseq.nim
@@ -20,10 +20,12 @@ proc grow(s: var ShSeq, size: int) =
   if size <= s.capacity:
     return
 
-  var tmp = cast[ptr UncheckedArray[T]](createU(T, size))
+  var tmp = cast[ptr UncheckedArray[T]](createSharedU(T, size))
   if s.len > 0:
     copyMem(addr tmp[0], addr s.items[0], s.len * sizeof(T))
   s.capacity = size
+  if s.items != nil:
+    deallocShared(s.items)
   s.items = tmp
 
 proc destroy*(s: var ShSeq) =

--- a/tests/main_tests.nim
+++ b/tests/main_tests.nim
@@ -6,6 +6,8 @@
 
 import net, os, unittest2, ../metrics
 
+import ./test_shseq
+
 when defined(metrics):
   import times
 
@@ -45,22 +47,21 @@ suite "counter":
       expect ValueError:
         var tmp = newCounter("1337", "invalid name")
 
-  when not defined(noAlter):
-    test "alternative API":
-      counter("one_off_counter").inc()
-      check counter("one_off_counter").value == 1
-      counter("one_off_counter").inc(0.5)
-      check counter("one_off_counter").value == 1.5
+  test "alternative API":
+    counter("one_off_counter").inc()
+    check counter("one_off_counter").value == 1
+    counter("one_off_counter").inc(0.5)
+    check counter("one_off_counter").value == 1.5
 
-      # # Can't have different collector types with the same name, but unittest
-      # # can't catch an exception raised in the assignment to a {.global.}
-      # # variable.
-      # expect RegistrationError:
-      # check gauge("one_off_counter").value == 0
+    # # Can't have different collector types with the same name, but unittest
+    # # can't catch an exception raised in the assignment to a {.global.}
+    # # variable.
+    # expect RegistrationError:
+    # check gauge("one_off_counter").value == 0
 
-      # colons in name
-      counter("one:off:counter:colons").inc()
-      check counter("one:off:counter:colons").value == 1
+    # colons in name
+    counter("one:off:counter:colons").inc()
+    check counter("one:off:counter:colons").value == 1
 
   test "exceptions":
     proc f(switch: bool) =
@@ -116,6 +117,14 @@ suite "counter":
     lCounter2.inc(labelValues = labelValues2)
     check lCounter2.value(labelValues2) == 1
 
+    declareCounter lCounter3, "l3 help", ["aaa"]
+    for i in 0 ..< 4:
+      for j in ["d", "b", "c", "a", "e"]:
+        lCounter3.inc(1, [j])
+
+    for j in ["d", "b", "c", "a", "e"]:
+      check lCounter3.value([j]) == 4
+
   test "sample rate":
     declareCounter sCounter, "counter with a sample rate set", registry = registry
     sCounter.inc()
@@ -159,12 +168,11 @@ suite "gauge":
   test "GlobalGauge value":
     check globalGauge.value == 0.0
 
-  when not defined(noAlter):
-    test "alternative API":
-      gauge("one_off_gauge").set(1)
-      check gauge("one_off_gauge").value == 1
-      gauge("one_off_gauge").inc(0.5)
-      check gauge("one_off_gauge").value == 1.5
+  test "alternative API":
+    gauge("one_off_gauge").set(1)
+    check gauge("one_off_gauge").value == 1
+    gauge("one_off_gauge").inc(0.5)
+    check gauge("one_off_gauge").value == 1.5
 
   test "in progress":
     myGauge.trackInProgress:
@@ -215,11 +223,10 @@ suite "summary":
     check mySummary.valueByName("mySummary_count") == 2
     check mySummary.valueByName("mySummary_sum") == 10.5
 
-  when not defined(noAlter):
-    test "alternative API":
-      summary("one_off_summary").observe(10)
-      check summary("one_off_summary").valueByName("one_off_summary_count") == 1
-      check summary("one_off_summary").valueByName("one_off_summary_sum") == 10
+  test "alternative API":
+    summary("one_off_summary").observe(10)
+    check summary("one_off_summary").valueByName("one_off_summary_count") == 1
+    check summary("one_off_summary").valueByName("one_off_summary_sum") == 10
 
   test "timing":
     mySummary.time:
@@ -298,23 +305,22 @@ suite "histogram":
     expect ValueError:
       declareHistogram h3, "help", registry = registry, buckets = [3.0, 1.0]
 
-  when not defined(noAlter):
-    test "alternative API":
-      histogram("one_off_histogram").observe(2)
-      check histogram("one_off_histogram").valueByName(
-        "one_off_histogram_bucket", [], ["1.0"]
-      ) == 0
-      check histogram("one_off_histogram").valueByName(
-        "one_off_histogram_bucket", [], ["2.5"]
-      ) == 1
-      check histogram("one_off_histogram").valueByName(
-        "one_off_histogram_bucket", [], ["5.0"]
-      ) == 1
-      check histogram("one_off_histogram").valueByName(
-        "one_off_histogram_bucket", [], ["+Inf"]
-      ) == 1
-      check histogram("one_off_histogram").valueByName("one_off_histogram_count") == 1
-      check histogram("one_off_histogram").valueByName("one_off_histogram_sum") == 2
+  test "alternative API":
+    histogram("one_off_histogram").observe(2)
+    check histogram("one_off_histogram").valueByName(
+      "one_off_histogram_bucket", [], ["1.0"]
+    ) == 0
+    check histogram("one_off_histogram").valueByName(
+      "one_off_histogram_bucket", [], ["2.5"]
+    ) == 1
+    check histogram("one_off_histogram").valueByName(
+      "one_off_histogram_bucket", [], ["5.0"]
+    ) == 1
+    check histogram("one_off_histogram").valueByName(
+      "one_off_histogram_bucket", [], ["+Inf"]
+    ) == 1
+    check histogram("one_off_histogram").valueByName("one_off_histogram_count") == 1
+    check histogram("one_off_histogram").valueByName("one_off_histogram_sum") == 2
 
   test "timing":
     myHistogram.time:

--- a/tests/main_tests.nim
+++ b/tests/main_tests.nim
@@ -16,7 +16,8 @@ declarePublicCounter globalPublicCounter, "help"
 declareGauge globalGauge, "help"
 declarePublicGauge globalPublicGauge, "help"
 
-const brokenGlobals = (NimMajor, NimMinor) == (2, 0) and (defined(gcOrc) or defined(gcArc))
+const brokenGlobals =
+  (NimMajor, NimMinor) == (2, 0) and (defined(gcOrc) or defined(gcArc))
 
 proc gcSafetyTest*() {.gcsafe.} = # The test is successful if this proc compiles
   globalCounter.inc 2

--- a/tests/main_tests.nim
+++ b/tests/main_tests.nim
@@ -16,6 +16,8 @@ declarePublicCounter globalPublicCounter, "help"
 declareGauge globalGauge, "help"
 declarePublicGauge globalPublicGauge, "help"
 
+const brokenGlobals = (NimMajor, NimMinor) == (2, 0) and (defined(gcOrc) or defined(gcArc))
+
 proc gcSafetyTest*() {.gcsafe.} = # The test is successful if this proc compiles
   globalCounter.inc 2
   globalPublicCounter.inc(2)
@@ -48,20 +50,23 @@ suite "counter":
         var tmp = newCounter("1337", "invalid name")
 
   test "alternative API":
-    counter("one_off_counter").inc()
-    check counter("one_off_counter").value == 1
-    counter("one_off_counter").inc(0.5)
-    check counter("one_off_counter").value == 1.5
+    when brokenGlobals:
+      skip()
+    else:
+      counter("one_off_counter").inc()
+      check counter("one_off_counter").value == 1
+      counter("one_off_counter").inc(0.5)
+      check counter("one_off_counter").value == 1.5
 
-    # # Can't have different collector types with the same name, but unittest
-    # # can't catch an exception raised in the assignment to a {.global.}
-    # # variable.
-    # expect RegistrationError:
-    # check gauge("one_off_counter").value == 0
+      # # Can't have different collector types with the same name, but unittest
+      # # can't catch an exception raised in the assignment to a {.global.}
+      # # variable.
+      # expect RegistrationError:
+      # check gauge("one_off_counter").value == 0
 
-    # colons in name
-    counter("one:off:counter:colons").inc()
-    check counter("one:off:counter:colons").value == 1
+      # colons in name
+      counter("one:off:counter:colons").inc()
+      check counter("one:off:counter:colons").value == 1
 
   test "exceptions":
     proc f(switch: bool) =
@@ -169,10 +174,13 @@ suite "gauge":
     check globalGauge.value == 0.0
 
   test "alternative API":
-    gauge("one_off_gauge").set(1)
-    check gauge("one_off_gauge").value == 1
-    gauge("one_off_gauge").inc(0.5)
-    check gauge("one_off_gauge").value == 1.5
+    when brokenGlobals:
+      skip()
+    else:
+      gauge("one_off_gauge").set(1)
+      check gauge("one_off_gauge").value == 1
+      gauge("one_off_gauge").inc(0.5)
+      check gauge("one_off_gauge").value == 1.5
 
   test "in progress":
     myGauge.trackInProgress:
@@ -224,9 +232,12 @@ suite "summary":
     check mySummary.valueByName("mySummary_sum") == 10.5
 
   test "alternative API":
-    summary("one_off_summary").observe(10)
-    check summary("one_off_summary").valueByName("one_off_summary_count") == 1
-    check summary("one_off_summary").valueByName("one_off_summary_sum") == 10
+    when brokenGlobals:
+      skip()
+    else:
+      summary("one_off_summary").observe(10)
+      check summary("one_off_summary").valueByName("one_off_summary_count") == 1
+      check summary("one_off_summary").valueByName("one_off_summary_sum") == 10
 
   test "timing":
     mySummary.time:
@@ -306,21 +317,24 @@ suite "histogram":
       declareHistogram h3, "help", registry = registry, buckets = [3.0, 1.0]
 
   test "alternative API":
-    histogram("one_off_histogram").observe(2)
-    check histogram("one_off_histogram").valueByName(
-      "one_off_histogram_bucket", [], ["1.0"]
-    ) == 0
-    check histogram("one_off_histogram").valueByName(
-      "one_off_histogram_bucket", [], ["2.5"]
-    ) == 1
-    check histogram("one_off_histogram").valueByName(
-      "one_off_histogram_bucket", [], ["5.0"]
-    ) == 1
-    check histogram("one_off_histogram").valueByName(
-      "one_off_histogram_bucket", [], ["+Inf"]
-    ) == 1
-    check histogram("one_off_histogram").valueByName("one_off_histogram_count") == 1
-    check histogram("one_off_histogram").valueByName("one_off_histogram_sum") == 2
+    when brokenGlobals:
+      skip()
+    else:
+      histogram("one_off_histogram").observe(2)
+      check histogram("one_off_histogram").valueByName(
+        "one_off_histogram_bucket", [], ["1.0"]
+      ) == 0
+      check histogram("one_off_histogram").valueByName(
+        "one_off_histogram_bucket", [], ["2.5"]
+      ) == 1
+      check histogram("one_off_histogram").valueByName(
+        "one_off_histogram_bucket", [], ["5.0"]
+      ) == 1
+      check histogram("one_off_histogram").valueByName(
+        "one_off_histogram_bucket", [], ["+Inf"]
+      ) == 1
+      check histogram("one_off_histogram").valueByName("one_off_histogram_count") == 1
+      check histogram("one_off_histogram").valueByName("one_off_histogram_sum") == 2
 
   test "timing":
     myHistogram.time:

--- a/tests/test_shseq.nim
+++ b/tests/test_shseq.nim
@@ -24,23 +24,26 @@ suite "ShSeq":
       s[1] == 1
 
   test "cross-thread init/destroy":
-    var s: ShSeq[int]
+    when defined(threads):
+      var s: ShSeq[int]
 
-    var t: Thread[ptr ShSeq[int]]
+      var t: Thread[ptr ShSeq[int]]
 
-    proc threadFunc(s: ptr ShSeq[int]) {.thread.} =
-      s[].add(2)
-      s[].add(1)
-      s[].add(0)
+      proc threadFunc(s: ptr ShSeq[int]) {.thread.} =
+        s[].add(2)
+        s[].add(1)
+        s[].add(0)
 
-    createThread(t, threadFunc, addr s)
+      createThread(t, threadFunc, addr s)
 
-    t.joinThread()
+      t.joinThread()
 
-    check:
-      s[0] == 2
+      check:
+        s[0] == 2
 
-    s.destroy()
+      s.destroy()
 
-    check:
-      s.len == 0
+      check:
+        s.len == 0
+    else:
+      skip()

--- a/tests/test_shseq.nim
+++ b/tests/test_shseq.nim
@@ -1,3 +1,5 @@
+{.used.}
+
 import unittest2, ../metrics/shseq
 
 suite "ShSeq":

--- a/tests/test_shseq.nim
+++ b/tests/test_shseq.nim
@@ -1,0 +1,22 @@
+import unittest2, ../metrics/shseq
+
+suite "ShSeq":
+  test "basics":
+    var s: ShSeq[int]
+
+    s.add(1)
+    s.add(2)
+    s.add(4)
+
+    s.insert(0, 0)
+    s.insert(3, 3)
+    s.insert(5, 5)
+
+    for i in 0 ..< s.len:
+      check s[i] == i
+
+  test "init":
+    let s = ShSeq.init([0, 1, 2])
+    check:
+      s.len == 3
+      s[1] == 1

--- a/tests/test_shseq.nim
+++ b/tests/test_shseq.nim
@@ -22,3 +22,25 @@ suite "ShSeq":
     check:
       s.len == 3
       s[1] == 1
+
+  test "cross-thread init/destroy":
+    var s: ShSeq[int]
+
+    var t: Thread[ptr ShSeq[int]]
+
+    proc threadFunc(s: ptr ShSeq[int]) {.thread.} =
+      s[].add(2)
+      s[].add(1)
+      s[].add(0)
+
+    createThread(t, threadFunc, addr s)
+
+    t.joinThread()
+
+    check:
+      s[0] == 2
+
+    s.destroy()
+
+    check:
+      s.len == 0


### PR DESCRIPTION
By allocating label metadata from thread-shared memory, we can allow the creation of new labels from any thread. Though metrics must still be registered from the main thread, general usage after registration becomes more flexible.

A downside of this approach is that memory for labels (and friends) is no longer managed by the GC meaning that it potentially leaks should one wish to release the registry - this does not have much practical impact since registered metrics typically stay around until the application ends but could have an impact on applications using custom registries.

Fixing the leak would require introducing an API for manually releasing the shared resources, an excercise left for the future.

A more forceful refactoring would also make `Collector` non-ref - this would allow registering new collectors from different threads as well making the library fully thread safe (at the expense of some breaking changes).

Of note is that we perform label lookups using a sorted sequence instead of a `Table` - this should make no practical difference since label cardinality is expected to be kept low.