### PR TITLE
update metrics.nimble version to 0.2.1

### DIFF
--- a/metrics.nimble
+++ b/metrics.nimble
@@ -1,7 +1,7 @@
 mode = ScriptMode.Verbose
 
 packageName = "metrics"
-version = "0.2.0"
+version = "0.2.1"
 author = "Status Research & Development GmbH"
 description = "Metrics client library supporting Prometheus"
 license = "MIT or Apache License 2.0"


### PR DESCRIPTION
Once we merge this we need to create a tag `v0.2.1` to align with metrics.nimble info.