### PR TITLE
fix: shadowing bug with `labelValues`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main
     with:
-      nimble-version: ef4ca1af68cfe9e827ea7048fe4e7d873a2f1717
+      nimble-version: 33e93f4a2516809e696d30ef7757d69f0cfe5079
       test-command: |
         nimble --requires:unittest2 test
         nimble --requires:unittest2 --requires:chronicles test_chronicles

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
   build:
     uses: status-im/nimbus-common-workflow/.github/workflows/common.yml@main
     with:
-      nimble-version: b920dad9ed76c6619be3ec0cfbf0dde6f9e39092
+      nimble-version: ef4ca1af68cfe9e827ea7048fe4e7d873a2f1717
       test-command: |
         nimble --requires:unittest2 test
         nimble --requires:unittest2 --requires:chronicles test_chronicles

--- a/metrics.nim
+++ b/metrics.nim
@@ -367,9 +367,10 @@ when defined(metrics):
       collector: Collector, labelValues: openArray[string] = []
   ): float64 {.gcsafe, raises: [KeyError].} =
     var res = NaN
+    # Capture labelValues in a seq to avoid shadowing in inner proc
+    let targetLabelValues = @labelValues
     # Don't access the "metrics" field directly, so we can support custom
     # collectors.
-    let targetLabelValues = labelValues
     {.gcsafe.}:
       proc findMetric(
           name: string,

--- a/metrics.nim
+++ b/metrics.nim
@@ -369,14 +369,15 @@ when defined(metrics):
     var res = NaN
     # Don't access the "metrics" field directly, so we can support custom
     # collectors.
+    let targetLabelValues = labelValues
     {.gcsafe.}:
       proc findMetric(
           name: string,
           value: float64,
-          labels, labelValues: openArray[string],
+          labels, metricLabelValues: openArray[string],
           timestamp: Time,
       ) =
-        if res != res and labelValues == labelValues:
+        if res != res and metricLabelValues == targetLabelValues:
           res = value
 
       collect(collector, findMetric)


### PR DESCRIPTION
```
proc valueImpl*(
    collector: Collector, labelValues: openArray[string] = []  # <-- outer labelValues
): float64 =
  var res = NaN
  {.gcsafe.}:
    proc findMetric(
        name: string,
        value: float64,
        labels, labelValues: openArray[string],  # <-- inner labelValues SHADOWS outer
        timestamp: Time,
    ) =
      if res != res and labelValues == labelValues:  # <-- always true (self-comparison)
        res = value
```