### PR TITLE
replace deprecated actions/checkout@v4 with actions/checkout@v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
   nph:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Check `nph` formatting
         uses: arnetheduck/nph-action@v1
         with:

--- a/metrics.nimble
+++ b/metrics.nimble
@@ -15,11 +15,10 @@ let lang = getEnv("NIMLANG", "c") # Which backend (c/cpp/js)
 let flags = getEnv("NIMFLAGS", "") # Extra flags for the compiler
 let verbose = getEnv("V", "") notin ["", "0"]
 
-from os import quoteShell
+from std/os import quoteShell
 
 let cfg =
-  " --styleCheck:usages --styleCheck:error" &
-  (if verbose: "" else: " --verbosity:0") &
+  " --styleCheck:usages --styleCheck:error" & (if verbose: "" else: " --verbosity:0") &
   " --skipParentCfg --skipUserCfg --outdir:build " &
   quoteShell("--nimcache:build/nimcache/$projectName") & " -d:metricsTest"
 

--- a/metrics.nimble
+++ b/metrics.nimble
@@ -19,7 +19,7 @@ from os import quoteShell
 
 let cfg =
   " --styleCheck:usages --styleCheck:error" &
-  (if verbose: "" else: " --verbosity:0 --hints:off") &
+  (if verbose: "" else: " --verbosity:0") &
   " --skipParentCfg --skipUserCfg --outdir:build " &
   quoteShell("--nimcache:build/nimcache/$projectName") & " -d:metricsTest"
 


### PR DESCRIPTION
Triggers
> Node 20 is being deprecated. This workflow is running with Node 24 by default. If you need to temporarily use Node 20, you can set the ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true environment variable. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/